### PR TITLE
Set Content-Length header firmly.

### DIFF
--- a/lib/OAuth/Lite/Consumer.pm
+++ b/lib/OAuth/Lite/Consumer.pm
@@ -701,7 +701,7 @@ sub gen_oauth_request {
     if ( $is_send_data_method ) {
         $headers->header('Content-Type', q{application/x-www-form-urlencoded})
             unless $headers->header('Content-Type');
-        $headers->header('Content-Length', bytes::length($content) );
+        $headers->header('Content-Length', bytes::length($content) || 0 );
     }
     my $req = HTTP::Request->new( $method, $url, $headers, $content );
     $req;

--- a/t/10_content_length.t
+++ b/t/10_content_length.t
@@ -1,0 +1,25 @@
+use strict;
+use warnings;
+use utf8;
+use Test::More;
+
+use OAuth::Lite::Consumer;
+
+# length(udnef) returns undef after perl 5.12+.
+
+my $c = OAuth::Lite::Consumer->new(
+    key          => 'kkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkk',
+    secret       => 'ssssssssssssssss',
+);
+my $req = $c->gen_oauth_request(
+    params => {
+        oauth_callback => "oob",
+    },
+    realm => "",
+    url   => "http://localhost/",
+);
+is($req->method, 'POST');
+is($req->content_length, 0);
+
+done_testing;
+


### PR DESCRIPTION
length(undef) returns undef on Perl 5.12+. So, if $content is undef, no Content-Length header is added on request.

This patch fixes "411 Length Required" issue.
