### PR TITLE
Add ua option to pod, which is already available

### DIFF
--- a/lib/OAuth/Lite/Consumer.pm
+++ b/lib/OAuth/Lite/Consumer.pm
@@ -170,6 +170,10 @@ See Also L<http://oauth.googlecode.com/svn/spec/ext/body_hash/1.0/drafts/4/spec.
 
 The base site url of Service Provider
 
+=item ua
+
+An instance of L<OAuth::Lite::Agent> used to request. (optional)
+
 =item request_token_path
 
 =item access_token_path


### PR DESCRIPTION
Hi.
I found `OAuth::Lite::Consumer->new` accepts `ua` option, but it is not documented in POD, so I added it.
https://github.com/lyokato/p5-oauth-lite/blob/43ca750006fe32b2c3399c605eefd91f8b3542cd/lib/OAuth/Lite/Consumer.pm#L271

Overriding `ua` is useful especially when consumers want to specify its UserAgent HTTP request header.